### PR TITLE
initializing some properties that psalm was complaining about, updating baseline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,17 @@ language: php
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
+
 env:
   global:
-    - COMPOSER_ARGS="" TMPDIR=/tmp USE_XDEBUG=false
+    - COMPOSER_ARGS=""
+    - TMPDIR=/tmp
+    - USE_XDEBUG=false
+    - COMPOSER_DISCARD_CHANGES=1
 
 branches:
   only:
@@ -49,20 +57,20 @@ jobs:
       env: COMPOSER_ARGS="--ignore-platform-reqs --prefer-lowest"
     - php: nightly
       env: COMPOSER_ARGS="--ignore-platform-reqs"
-      
+
     - stage: style check
       php: 7.2
       env: TMPDIR=/tmp USE_XDEBUG=false
       script:
         - composer style-check
-        
+
     - stage: static analysis
       php: 7.2
       env: TMPDIR=/tmp USE_XDEBUG=false
       script:
         - composer phpstan
         - composer psalm
-        
+
     - stage: test with coverage
       php: 7.2
       env: TMPDIR=/tmp USE_XDEBUG=true CC_TEST_REPORTER_ID=ec76409b1e3d0a9f7e693fdcc5da91447eb34e2a207733f7ec0b1cdf549a726a

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,18 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files>
-  <file src="src/Zend/Config.php">
-    <PropertyNotSetInConstructor occurrences="5">
-      <code>$_skipNextIteration</code>
-      <code>$_allowModifications</code>
-      <code>$_index</code>
-      <code>$_count</code>
-      <code>$_data</code>
-    </PropertyNotSetInConstructor>
-  </file>
   <file src="src/Zend/Config/Ini.php">
-    <InvalidArgument occurrences="1">
-      <code>array($this, '_loadFileErrorHandler')</code>
-    </InvalidArgument>
     <PossiblyFalseIterator occurrences="1">
       <code>$loaded</code>
     </PossiblyFalseIterator>
@@ -24,16 +12,12 @@
     <DocblockTypeContradiction occurrences="1">
       <code>is_array($dataArray)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="1">
-      <code>array($this, '_loadFileErrorHandler')</code>
-    </InvalidArgument>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>is_array($options)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Zend/Config/Xml.php">
-    <InvalidArgument occurrences="2">
-      <code>array($this, '_loadFileErrorHandler')</code>
+    <InvalidArgument occurrences="1">
       <code>$xmlObject-&gt;attributes()</code>
     </InvalidArgument>
     <PossiblyFalseIterator occurrences="1">
@@ -50,12 +34,8 @@
     <DocblockTypeContradiction occurrences="1">
       <code>is_array($dataArray)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="1">
-      <code>array($this, '_loadFileErrorHandler')</code>
-    </InvalidArgument>
-    <RedundantConditionGivenDocblockType occurrences="3">
+    <RedundantConditionGivenDocblockType occurrences="2">
       <code>is_array($options)</code>
-      <code>is_array($dataArray)</code>
       <code>is_array($value)</code>
     </RedundantConditionGivenDocblockType>
   </file>

--- a/src/Zend/Config.php
+++ b/src/Zend/Config.php
@@ -33,28 +33,28 @@ class Zend_Config implements Countable, Iterator
      *
      * @var boolean
      */
-    protected $_allowModifications;
+    protected $_allowModifications = false;
 
     /**
      * Iteration index
      *
      * @var integer
      */
-    protected $_index;
+    protected $_index = 0;
 
     /**
      * Number of elements in configuration data
      *
      * @var integer
      */
-    protected $_count;
+    protected $_count = 0;
 
     /**
      * Contains array of configuration data
      *
      * @var array
      */
-    protected $_data;
+    protected $_data = array();
 
     /**
      * Used when unsetting values during iteration to ensure we do not skip
@@ -62,7 +62,7 @@ class Zend_Config implements Countable, Iterator
      *
      * @var boolean
      */
-    protected $_skipNextIteration;
+    protected $_skipNextIteration = false;
 
     /**
      * Contains which config file sections were loaded. This is null


### PR DESCRIPTION
Not sure why Psalm failed the last cron build of this, I assume something updated in how it sees some of these uninitialized properties, causing a new one to appear in the output that the baseline didn't cover.

Instead of ignoring all of these, I've changed them to be initialized to what would more or less be their initial value (based on how the code is checking them). Many of these are set in `Zend_Config`'s constructor, but Psalm doesn't seem to see that constructor being called by `Zend_Config_Xml`'s constructor.